### PR TITLE
BUILD: fix linker error for PathRemoveFileSpecW

### DIFF
--- a/ContextMenuImplementation/ContextMenuImplementation.vcxproj
+++ b/ContextMenuImplementation/ContextMenuImplementation.vcxproj
@@ -187,7 +187,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;Pathcch.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>Source.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/ContextMenuImplementation/dllmain.cpp
+++ b/ContextMenuImplementation/dllmain.cpp
@@ -5,9 +5,8 @@
 #include <shobjidl_core.h>
 #include <wil/resource.h>
 #include <Shellapi.h>
-#include <Shlwapi.h>
 #include <Strsafe.h>
-
+#include <pathcch.h>
 
 using namespace Microsoft::WRL;
 
@@ -65,7 +64,7 @@ public:
                 WCHAR modulePath[MAX_PATH];
                 if (GetModuleFileNameW(g_hModule, modulePath, ARRAYSIZE(modulePath)))
                 {
-                    PathRemoveFileSpecW(modulePath);
+                    PathCchRemoveFileSpec(modulePath, ARRAYSIZE(modulePath));
                     StringCchCatW(modulePath, ARRAYSIZE(modulePath), L"\\Notepad.ico");
 
                     auto iconPathStr = wil::make_cotaskmem_string_nothrow(modulePath);


### PR DESCRIPTION
BUILD: fix linker error by removing deprecated PathRemoveFileSpecW usage in favor of PathCchRemoveFileSpec and adding pathcch.lib dependency.