### PR TITLE
Update dllmain.cpp

### DIFF
--- a/ContextMenuImplementation/dllmain.cpp
+++ b/ContextMenuImplementation/dllmain.cpp
@@ -116,8 +116,12 @@ public:
     IFACEMETHODIMP GetCanonicalName(_Out_ GUID* guidCommandName) { *guidCommandName = GUID_NULL;  return S_OK; }
     IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* selection, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState)
     {
-        *cmdState = ECS_ENABLED;
-        return S_OK;
+        if (selection && okToBeSlow)
+            {
+                *cmdState = ECS_ENABLED;
+                return S_OK;
+            }
+            *cmdState = ECS_HIDDEN; 
     }
 
     IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* selection, _In_opt_ IBindCtx*) noexcept try


### PR DESCRIPTION
Hide the context menu in the classic style and exclusively display it within the new Windows 11 context menu. Additionally, incorporate Windows 11 checks to ensure its compatibility with other Windows versions as needed.